### PR TITLE
encode redirect URL in onedrive sign in request

### DIFF
--- a/onedrive_client.js
+++ b/onedrive_client.js
@@ -20,7 +20,7 @@ OneDrive.requestCredential = function (options, credentialRequestCompleteCallbac
   }
   var credentialToken = Random.secret();
 
-  var scope = (options && options.requestPermissions) || ["wl.basic","wl.skydrive","wl.emails"];
+  var scope = (options && options.requestPermissions) || ["wl.basic","wl.skydrive","wl.emails","wl.offline_access"];
   var flatScope = _.map(scope, encodeURIComponent).join('+');
 
   var loginStyle = OAuth._loginStyle('onedrive', config, options);
@@ -30,7 +30,7 @@ OneDrive.requestCredential = function (options, credentialRequestCompleteCallbac
     '?client_id=' + config.clientId +
     '&scope=' + flatScope +
     '&response_type=code' +
-    '&redirect_uri=' + OAuth._redirectUri('onedrive', config) +
+    '&redirect_uri=' + encodeURI(OAuth._redirectUri('onedrive', config)) +
     '&state=' + OAuth._stateParam(loginStyle, credentialToken);
   OAuth.launchLogin({
     loginService: "onedrive",


### PR DESCRIPTION
According to https://msdn.microsoft.com/EN-US/library/office/dn659750.aspx
Replace REDIRECT_URI with the Uniform Resource Identifier (URI) of your callback webpage. The callback URI must use URL escape codes, such as %20 for spaces, %3A for colons, and %2F for forward slashes.